### PR TITLE
Fix Bug 859321 - Account for 2px border on trackevents in start/end calc...

### DIFF
--- a/public/src/core/views/track-view.js
+++ b/public/src/core/views/track-view.js
@@ -50,7 +50,8 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop" ],
 
             // Avoid using width values to derive end value to circumvent padding/border issues.
             duration = trackEvent.popcornOptions.end - trackEvent.popcornOptions.start;
-            left = trackEventRect.left - trackRect.left;
+            // Account for 2 pixel border.
+            left = ( trackEventRect.left + 2 ) - trackRect.left;
             start = left / trackRect.width * _duration;
             end = start + duration;
 


### PR DESCRIPTION
...s for dragging

https://bugzilla.mozilla.org/show_bug.cgi?id=859321
