### PR TITLE
Fix Bug 889927 - Up/Down keys no longer destroy trackevent when just upd...

### DIFF
--- a/public/src/core/track.js
+++ b/public/src/core/track.js
@@ -280,6 +280,7 @@ define( [ "./eventmanager", "./trackevent", "./views/track-view", "util/sanitize
      * Method removeTrackEvent
      *
      * @param {Object} trackEvent: The trackEvent to be removed from this track
+     * @param {Boolean} preventRemove: This prevents the removal of the trackevent from the Popcorn Instance.
      */
     this.removeTrackEvent = function( trackEvent, preventRemove ) {
       var idx = _trackEvents.indexOf( trackEvent );

--- a/public/src/ui/ui.js
+++ b/public/src/ui/ui.js
@@ -383,7 +383,7 @@ define( [ "core/eventmanager", "./toggler",
           track = trackEvent.track;
           nextTrack = butter.currentMedia.getLastTrack( track );
           if ( nextTrack && !nextTrack.findOverlappingTrackEvent( trackEvent ) ) {
-            track.removeTrackEvent( trackEvent );
+            track.removeTrackEvent( trackEvent, true );
             nextTrack.addTrackEvent( trackEvent );
           }
         }
@@ -435,7 +435,7 @@ define( [ "core/eventmanager", "./toggler",
           track = trackEvent.track;
           nextTrack = butter.currentMedia.getNextTrack( track );
           if ( nextTrack && !nextTrack.findOverlappingTrackEvent( trackEvent ) ) {
-            track.removeTrackEvent( trackEvent );
+            track.removeTrackEvent( trackEvent, true );
             nextTrack.addTrackEvent( trackEvent );
           }
         }


### PR DESCRIPTION
...ating zindex

https://bugzilla.mozilla.org/show_bug.cgi?id=889927
