### PR TITLE
[#897327] Ensure play when ready is only delayed because of active loadi...

### DIFF
--- a/public/templates/assets/plugins/sequencer/popcorn.sequencer.js
+++ b/public/templates/assets/plugins/sequencer/popcorn.sequencer.js
@@ -253,7 +253,7 @@
 
       // While clip is loading, do not let the timeline play.
       options.playIfReady = function() {
-        if ( options.playWhenReady && !loadingHandler.loading.length ) {
+        if ( options.playWhenReady && !_waiting ) {
           options.playWhenReady = false;
           _this.play();
           return true;


### PR DESCRIPTION
...ng events, and not unactive.
