### PR TITLE
Bug 898139 - update makeapi-client version to v0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "knox": "0.8.3",
     "less": "1.3.3",
     "less-middleware": "0.1.12",
-    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.5",
+    "makeapi-client": "https://github.com/mozilla/makeapi-client/tarball/v0.5.6",
     "mysql": "2.0.0-alpha8",
     "nconf": "0.6.7",
     "newrelic": "0.9.20",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=898139
