### PR TITLE
Fix Bug 902310 - Use SVG Logo as image plugin default

### DIFF
--- a/public/templates/assets/plugins/image/popcorn.image.js
+++ b/public/templates/assets/plugins/image/popcorn.image.js
@@ -313,7 +313,7 @@
           elem: "input",
           type: "url",
           label: "Source URL",
-          "default": "http://www.mozilla.org/media/img/home/firefox.png"
+          "default": "https://popcorn.webmaker.org/resources/popcorn-logo.svg"
         },
         linkSrc: {
           elem: "input",


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=902310
