### PR TITLE
Bug 925759 - don't use loginAPI's deprecated getUser function

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "sequelize": "1.6.0",
     "shelljs": "0.1.2",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.4.tar.gz",
-    "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.11",
+    "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.14",
     "webmaker-mediasync": "https://github.com/mozilla/webmaker-mediasync/tarball/v0.1.22",
     "webmaker-sso": "https://github.com/jbuck/node-webmaker-sso/tarball/v0.0.4"
   },

--- a/routes/api/projectResponse.js
+++ b/routes/api/projectResponse.js
@@ -34,7 +34,7 @@ module.exports = function( Project ) {
 
           req.projectJSON.remixedFrom = doc.id;
 
-          loginClient.getUser( doc.email, function( err, user ) {
+          loginClient.getUserByEmail( doc.email, function( err, user ) {
             if ( err || !user ) {
               // If there's an error, user doesn't exist on loginapi so we use popcorn.wmc.o
               // Or there could actually be an error of some sort.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=925759
