### PR TITLE
bug927860 - Update webmaker-loginapi to v 0.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "sequelize": "1.6.0",
     "shelljs": "0.1.2",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.2.7.tar.gz",
-    "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.16",
+    "webmaker-loginapi": "https://github.com/mozilla/node-webmaker-loginapi/tarball/v0.1.17",
     "webmaker-mediasync": "https://github.com/mozilla/webmaker-mediasync/tarball/v0.1.23",
     "webmaker-sso": "https://github.com/jbuck/node-webmaker-sso/tarball/v0.0.4"
   },


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=927860
