### PR TITLE
bug903611: Fixed a href and changed it to button

### DIFF
--- a/locale/en_US/popcorn.webmaker.org.json
+++ b/locale/en_US/popcorn.webmaker.org.json
@@ -22,7 +22,7 @@
 	"Center": "Center",
 	"Change the name of your project": "Change the name of your project",
 	"Clear Events": "Clear Events",
-	"Click to remove warning": "Click <a href=\"#\" class=\"close-button\">here</a> to remove this warning.",
+	"Click to remove warning": "Click <i class=\"icon-remove boxclose\" id="boxclose"></i> to remove this warning.",
 	"Clip editor": "Clip editor",
 	"Clip Title": "Clip Title",
 	"Clip title": "Clip title",


### PR DESCRIPTION
Original Request from aali:

> > > We have a link in Popcorn maker to close or hide the message.
> > > We want to change from using <a href> to <button> or <span>

If you want all links in popcorn maker to use button instead of <a href="#"></a>. I found out that the following files have <a href="#"></a> however I will fix the mistake you highlighted in your comment for now.

> public/test/manual-tests/index.html
> public/test/manual-tests/index.html  
> public/test/manual-tests/index.html
> views/embed-shell.html
> views/embed.html
