### PR TITLE
csrf-token rename

### DIFF
--- a/public/src/util/xhr.js
+++ b/public/src/util/xhr.js
@@ -3,7 +3,7 @@
  * obtain one at https://raw.github.com/mozilla/butter/master/LICENSE */
 
 (function() {
-  var __csrfToken = document.querySelector("meta[name=X-CSRF-Token]").content;
+  var __csrfToken = document.querySelector("meta[name=csrf-token]").content;
 
   var defaultErrorHandler = function( xhr, statusText, errorThrown ) {
     if ( console && console.error ) {
@@ -77,7 +77,7 @@
         method: "POST",
         url: url,
         header: {
-          "x-csrf-token": __csrfToken,
+          "X-CSRF-Token": __csrfToken, // express.js uses a non-standard name for csrf-token
           "Accept": "application/json"
         },
         data: data,
@@ -89,7 +89,7 @@
         method: "PUT",
         url: url,
         header: {
-          "x-csrf-token": __csrfToken,
+          "X-CSRF-Token": __csrfToken, // express.js uses a non-standard name for csrf-token
           "Accept": "application/json"
         },
         data: data,

--- a/views/editor.html
+++ b/views/editor.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width">
-  <meta name="X-CSRF-Token" content="{{csrf}}">
+  <meta name="csrf-token" content="{{csrf}}">
   <meta name="persona-email" content="{{personaEmail}}">
   <link rel="stylesheet" href="/templates/basic/style.css">
   <link rel="stylesheet" href="{{config.user_bar}}/css/nav.css">


### PR DESCRIPTION
switch from "X-CSRF-Token" as meta name to the validation-passing "csrf-token"

https://bugzilla.mozilla.org/show_bug.cgi?id=930166
