### PR TITLE
Fix Bug 906079 - Make project author name in embeds link to a webmaker\....

### DIFF
--- a/public/css/embed.less
+++ b/public/css/embed.less
@@ -263,6 +263,14 @@ body {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  > a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 
@@ -456,6 +464,14 @@ body {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+
+    > a {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
 }

--- a/routes/api/publish.js
+++ b/routes/api/publish.js
@@ -1,6 +1,7 @@
 var async = require( "async" ),
     metrics = require( "../../lib/metrics" ),
     s3 = require( "../../lib/s3" ),
+    config = require( "../../lib/config" ),
     sanitizer = require( "../../lib/sanitizer" ),
     utilities = require( "../../lib/utilities" );
 
@@ -17,6 +18,7 @@ module.exports = function( req, res ) {
         id: res.locals.project.id,
         author: res.locals.project.author,
         title: res.locals.project.name,
+        webmakerURL: config.AUDIENCE,
         description: description,
         embedShellSrc: publishUrl,
         projectUrl: projectUrl,

--- a/views/embed.html
+++ b/views/embed.html
@@ -50,7 +50,11 @@
             <div>
               <div class="mozpopcorn">Popcorn Maker</div>
               <div class="embed-title">{{title | safe }}</div>
-              <div class="embed-author">{{author}}</div>
+              {% if author %}
+                <div class="embed-author">
+                  <a href="{{webmakerURL}}/{{localeInfo.lang}}/u/{{author}}" target="_blank">{{author}}</a>
+                </div>
+              {% endif %}
             </div>
             <div class="post-roll-description">{{description | safe }}
               <br>
@@ -103,7 +107,9 @@
         <div class="attribution-mopop">Mozilla Popcorn</div>
         <div class="attribution-title">{{title | safe}}</div>
         {% if author %}
-          <div class="attribution-author">{{author}}</div>
+          <div class="attribution-author">
+            <a href="{{webmakerURL}}/{{localeInfo.lang}}/u/{{author}}" target="_blank">{{author}}</a>
+          </div>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
...org search of their username

https://bugzilla.mozilla.org/show_bug.cgi?id=906079
