### PR TITLE
Added a "durationchange" message type to the embedded player.

### DIFF
--- a/public/src/embed.js
+++ b/public/src/embed.js
@@ -267,6 +267,13 @@ function init() {
       });
     }
 
+    popcorn.on( "durationchange", function() {
+      window.parent.postMessage({
+        duration: popcorn.duration(),
+        type: "durationchange"
+      }, "*" );
+    });
+
     popcorn.on( "timeupdate", function() {
       window.parent.postMessage({
         currentTime: popcorn.currentTime(),


### PR DESCRIPTION
The message is sent with the duration of the popcorn project.

Example Usage:

```
window.addEventListener('message', function(message){
    if(message.data.type == 'durationchange'){
        console.log('make duration: %s', message.data.duration);
    }
});
```
