### PR TITLE
[#958314] Return HTML5 again on media checks if doesn't match a service....

### DIFF
--- a/public/src/util/mediatypes.js
+++ b/public/src/util/mediatypes.js
@@ -76,6 +76,7 @@ define( [ "localized", "util/uri", "json!/api/butterconfig" ],
           }
         }
       }
+      return "HTML5";
     },
     getMetaData: function( baseUrl, successCallback, errorCallback ) {
       var id,


### PR DESCRIPTION
... Likely means the clip is html video, audio or image.
