### PR TITLE
[#958560] Ensure old projects with english default layer names saved get...

### DIFF
--- a/public/src/core/track.js
+++ b/public/src/core/track.js
@@ -7,7 +7,12 @@ define( [ "localized", "./eventmanager", "./trackevent", "./views/track-view", "
 
   var __guid = 0,
       NAME_PREFIX = Localized.get( "Layer" ) + " ",
-      defaultNameRegex = new RegExp( "^" + NAME_PREFIX + "(\\d)+$" ),
+      // Old layer names can be saved as Layer n before l10n existed,
+      // these names are default names and should be translated.
+      // If we are going to start using this,
+      // we should check if it's the translated or english default, and update it.
+      defaultNameRegexTranslated = new RegExp( "^" + NAME_PREFIX + "(\\d)+$" ),
+      defaultNameRegex = new RegExp( "^" + "Layer " + "(\\d)+$" ),
       Track;
 
   Track = function( options ) {
@@ -95,7 +100,7 @@ define( [ "localized", "./eventmanager", "./trackevent", "./views/track-view", "
       name: {
         enumerable: true,
         get: function(){
-          if ( !_name || defaultNameRegex.test( _name ) ) {
+          if ( !_name || defaultNameRegexTranslated.test( _name ) || defaultNameRegex.test( _name ) ) {
             return NAME_PREFIX + _order;
           }
           return _name;
@@ -128,7 +133,7 @@ define( [ "localized", "./eventmanager", "./trackevent", "./views/track-view", "
           };
         },
         set: function( importData ) {
-          if( importData.name && !defaultNameRegex.test( importData.name ) ){
+          if( importData.name && !defaultNameRegexTranslated.test( importData.name ) && !defaultNameRegex.test( importData.name ) ){
             _name = importData.name;
           }
           if( importData.trackEvents ){

--- a/public/src/timeline/trackhandles.js
+++ b/public/src/timeline/trackhandles.js
@@ -123,7 +123,7 @@ define( [ "dialog/dialog", "util/dragndrop", "util/lang", "util/keys", "text!lay
 
       titleInputElement.addEventListener( "keypress", onKeypress, false );
 
-      track.listen( "tracknamechanged", function( e ) {
+      track.listen( "tracknamechanged", function() {
         titleElement.textContent = track.name;
         titleElement.title = track.name;
       });

--- a/public/templates/basic/saved-data.json
+++ b/public/templates/basic/saved-data.json
@@ -12,7 +12,7 @@
         "duration": 30,
         "controls": false,
         "tracks": [{
-            "name": "Layer 0",
+            "name": "",
             "id": "0",
             "trackEvents": []
             }]


### PR DESCRIPTION
...s cleared, and then defaulted to the translated version, from here on out we no longer save default layer names, just custom names, which cannot be translated at the moment.
