### PR TITLE
Bug 963231 - Check for shift key with comma on tag input to allow for '<'

### DIFF
--- a/public/src/ui/widget/ProjectDetails.js
+++ b/public/src/ui/widget/ProjectDetails.js
@@ -106,7 +106,7 @@ define( [ "util/keys", "ui/widget/tooltip", "localized", "ui/widget/textbox" ],
         }
 
         input.addEventListener( "keydown", function( e ) {
-          if ( e.keyCode === KEYS.ENTER || e.keyCode === KEYS.COMMA ) {
+          if ( e.keyCode === KEYS.ENTER || ( !e.shiftKey && e.keyCode === KEYS.COMMA ) ) {
             e.preventDefault();
             addTags( encodeURIComponent( e.target.value ) );
             input.value = "";


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=963231
