### PR TITLE
Fix Bug 965067 - Make Wikipedia always access resources over HTTPS

### DIFF
--- a/public/templates/assets/plugins/wikipedia/popcorn.wikipedia.js
+++ b/public/templates/assets/plugins/wikipedia/popcorn.wikipedia.js
@@ -147,9 +147,9 @@
     if ( options.src ) {
 
       _query = options.src + options.lang;
-      _href = "//" + encodeURIComponent( options.lang ) + ".wikipedia.org/w/";
+      _href = "https://" + encodeURIComponent( options.lang ) + ".wikipedia.org/w/";
       _title = options.src.slice( options.src.lastIndexOf( "/" ) + 1 );
-      options._link = "//" + encodeURIComponent( options.lang + ".wikipedia.org/wiki/" + _title );
+      options._link = "https://" + encodeURIComponent( options.lang + ".wikipedia.org/wiki/" + _title );
 
       if ( !cachedArticles[ _query ] ) {
         // gets the mobile format, so that we don't load unwanted images when the respose is turned into a documentFragment


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=965067
