### PR TITLE
Fix Bug 965063 - Force all uses of Google Fonts to use HTTPS

### DIFF
--- a/public/templates/assets/plugins/popup/popcorn.popup.js
+++ b/public/templates/assets/plugins/popup/popcorn.popup.js
@@ -464,7 +464,7 @@
         // Apply all the styles
         textContainer.style.fontFamily = options.fontFamily ? originalFamily : DEFAULT_FONT;
       };
-      fontSheet.href = "//fonts.googleapis.com/css?family=" + options.fontFamily.replace( /\s/g, "+" );
+      fontSheet.href = "https://fonts.googleapis.com/css?family=" + options.fontFamily.replace( /\s/g, "+" );
 
       options.toString = function() {
         return options.text || options._natives.manifest.options.text[ "default" ];

--- a/public/templates/assets/plugins/text/popcorn.text.js
+++ b/public/templates/assets/plugins/text/popcorn.text.js
@@ -288,7 +288,7 @@
           innerDiv.innerHTML = text;
         }
       };
-      fontSheet.href = "//fonts.googleapis.com/css?family=" + options.fontFamily.replace( /\s/g, "+" ) + ":400,700";
+      fontSheet.href = "https://fonts.googleapis.com/css?family=" + options.fontFamily.replace( /\s/g, "+" ) + ":400,700";
 
       options.toString = function() {
         // use the default option if it doesn't exist


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=965063
