### PR TITLE
Fix Bug 967034 - Have long trackevent titles ellipsis at the end if trac...

### DIFF
--- a/public/css/tray-timeline.less
+++ b/public/css/tray-timeline.less
@@ -138,6 +138,9 @@
     text-align: left;
     line-height: 25px;
     color: @baseText;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
   .butter-track-event-icon {
     float: left;


### PR DESCRIPTION
...kevent isn't wide enough

https://bugzilla.mozilla.org/show_bug.cgi?id=967034
