### PR TITLE
initialization of RECESS for less linting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,14 +45,47 @@ module.exports = function( grunt ) {
           }]
         }
       }
+    },
+    lesslint: {
+      src: [
+        "public/css/butter.ui.less",
+        "public/css/embed.less"
+      ],
+      options: {
+        csslint: {
+          "adjoining-classes": false,
+          "box-model": false,
+          "box-sizing": false,
+          "bulletproof-font-face": false,
+          "compatible-vendor-prefixes": false,
+          "duplicate-background-images": false,
+          "fallback-colors": false,
+          "ids": false,
+          "important": false,
+          "outline-none": false,
+          "overqualified-elements": false,
+          "qualified-headings": false,
+          "regex-selectors": false,
+          "star-property-hack": false,
+          "underscore-property-hack": false,
+          "universal-selector": false,
+          "unique-headings": false,
+          "unqualified-attributes": false,
+          "vendor-prefix": false,
+          "zero-units": false
+        }
+      }
     }
   });
 
   grunt.loadNpmTasks( "grunt-contrib-jshint" );
   grunt.loadNpmTasks( "grunt-cssjanus" );
   grunt.loadNpmTasks( "grunt-string-replace" );
+  grunt.loadNpmTasks( "grunt-lesslint" );
 
-  grunt.registerTask( "default", [ "jshint" ] );
+  grunt.registerTask( "default", [ "jshint", "lesslint" ] );
   grunt.registerTask( "build", [ "cssjanus", "string-replace" ]);
 
+
 };
+

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "popcorn-js": "1.5.6",
     "ua-parser-js": "0.6.2",
     "webmaker-analytics": "0.0.5",
-    "webmaker-language-picker": "0.0.16",
+    "webmaker-language-picker": "0.0.20",
     "webmaker-i18n": "https://github.com/mozilla/node-webmaker-i18n/archive/v0.3.11.tar.gz",
     "webmaker-auth-client": "0.0.26"
   }

--- a/package.json
+++ b/package.json
@@ -119,11 +119,12 @@
   },
   "devDependencies": {
     "awsbox": "0.4.2",
-    "grunt": "0.4.1",
+    "grunt": "0.4.2",
     "grunt-contrib-jshint": "0.4.3",
     "grunt-cssjanus": "0.2.2",
     "grunt-string-replace": "0.2.7",
     "grunt-lint5": "0.1.4",
+    "grunt-lesslint": "1.1.0",
     "supertest": "0.5.1",
     "tap": "0.4.0"
   },

--- a/public/css/header.less
+++ b/public/css/header.less
@@ -1,8 +1,13 @@
-@import "@{language-bower-path}/webmaker-language-picker/styles/languages";
+@language-bower-path: "../..";
+@bower-path: "../static/bower";
+@colors-path: "../../../../css";
+@import "@{bower-path}/webmaker-language-picker/styles/languages";
 @import "../static/bower/persona-btn/persona-btn";
 
-@language-bower-path: "../static/bower";
 @personaBtnPath: "../static/bower/persona-btn";
+@import "@{bower-path}/webmaker-language-picker/styles/languages";
+@import "../static/bower/persona-btn/persona-btn.css";
+
 
 /*********************************************************
 * HEADER


### PR DESCRIPTION
Regarding to bug https://bugzilla.mozilla.org/show_bug.cgi?id=982195 here is implementation of RECESS LESS linting for popcorn.webmaker.org. Gruntfile.js is configured to run recess, but needs to be installed grunt-recess module first.
