### PR TITLE
bug 1084627 - fixed media gallery spinner not becoming hidden

### DIFF
--- a/public/css/ui-states.less
+++ b/public/css/ui-states.less
@@ -61,7 +61,8 @@
   display: inline-block;
   background-image: url( "../resources/icons/spinny.gif" );
   &.hidden {
-    display: none;
+    /* conflict with .media-editor .media-loading-spinner.media-gallery-loading */
+    display: none !important;
   }
 }
 

--- a/public/src/editor/media-gallery-editor.js
+++ b/public/src/editor/media-gallery-editor.js
@@ -59,16 +59,15 @@ define( [ "localized", "util/lang", "util/uri", "util/xhr", "util/keys", "util/m
     _searchInput.classList.remove( "error" );
     _addMediaPanel.classList.remove( "invalid-field" );
     _errorMessage.classList.add( "hidden" );
-    _loadingSpinner.classList.add( "hidden" );
-
     _addBtn.classList.add( "hidden" );
+    deactivateSpinner();
   }
 
   function onDenied( error, preventFieldHightlight ) {
     clearTimeout( _cancelSpinner );
     clearTimeout( _mediaLoadTimeout );
     _errorMessage.innerHTML = error;
-    _loadingSpinner.classList.add( "hidden" );
+    deactivateSpinner();
     if ( !preventFieldHightlight ) {
       _addMediaPanel.classList.add( "invalid-field" );
     }
@@ -224,7 +223,7 @@ define( [ "localized", "util/lang", "util/uri", "util/xhr", "util/keys", "util/m
       el.removeChild( deleteBtn );
     }
 
-    _loadingSpinner.classList.add( "hidden" );
+    deactivateSpinner();
 
     el.querySelector( ".mg-title" ).innerHTML = data.title;
     el.querySelector( ".mg-type" ).classList.add( data.type.toLowerCase() + "-icon" );
@@ -347,7 +346,7 @@ define( [ "localized", "util/lang", "util/uri", "util/xhr", "util/keys", "util/m
     MediaUtils.getMetaData( data.source, onSuccess, function() {
       clearTimeout( _cancelSpinner );
       clearTimeout( _mediaLoadTimeout );
-      _loadingSpinner.classList.add( "hidden" );
+      deactivateSpinner();
       pagingSearchCallback( _itemContainers.project, 1 );
     });
   }
@@ -365,8 +364,8 @@ define( [ "localized", "util/lang", "util/uri", "util/xhr", "util/keys", "util/m
     clearTimeout( _cancelSpinner );
     clearTimeout( _mediaLoadTimeout );
     _addMediaPanel.classList.remove( "invalid-field" );
-    _loadingSpinner.classList.add( "hidden" );
     _errorMessage.classList.add( "hidden" );
+    deactivateSpinner();
   }
 
   function onEnter( e ) {
@@ -425,6 +424,13 @@ define( [ "localized", "util/lang", "util/uri", "util/xhr", "util/keys", "util/m
         container: _galleryList,
         remove: true
       });
+    }
+  }
+
+  function deactivateSpinner() {
+    var allSpinnerElements = _parentElement.querySelectorAll( ".media-loading-spinner" );
+    for ( var i = 0 ; i < allSpinnerElements.length; ++i ) {
+      allSpinnerElements[i].classList.add( "hidden" );
     }
   }
 


### PR DESCRIPTION
when two tabs contained a spinner image after starting searches with
different tabs activated only the spinner in the first tab would get
disabled.
