### PR TITLE
Change 'close warning' link to button

### DIFF
--- a/locale/en_US/popcorn.webmaker.org.json
+++ b/locale/en_US/popcorn.webmaker.org.json
@@ -22,7 +22,6 @@
 	"Center": "Center",
 	"Change the name of your project": "Change the name of your project",
 	"Clear Events": "Clear Events",
-	"Click to remove warning": "Click <a class=\"close-button\">here</a> to remove this warning.",
 	"Clip editor": "Clip editor",
 	"Clip Title": "Clip Title",
 	"Clip title": "Clip title",

--- a/public/css/ui-states.less
+++ b/public/css/ui-states.less
@@ -23,24 +23,29 @@
   background: @red;
   z-index: @HEADER_Z_INDEX + 10;
   font-size: 10pt;
-  text-align: left;
-  line-height: 1.2;
-  overflow: hidden;
-  span {
-    margin-top: -100%;
-    display: block;
-    position: relative;
-    padding: 1em;
-    .box-sizing( border-box );
-    .transition( margin-top 0.2s linear 1s);
+  .box-sizing( border-box );
+  .transform( scaleY(0) );
+  .transform-origin( top );
+  .transition( transform 0.2s linear 1s );
+  &.slide-out {
+    .transform( scaleY(1) );
   }
-  &.slide-out span {
-    margin-top: 0;
+  span {
+    display: block;
+    padding: 1em;
+    line-height: 1.2;
   }
   a {
     color: #FFF;
     text-decoration: underline;
     cursor: pointer;
+  }
+  button {
+    float: right;
+    margin: 0.4em;
+    padding: 4px 6px;
+    border: 1px solid #FFF;
+    background: transparent;
   }
 }
 

--- a/public/src/layouts/warn.html
+++ b/public/src/layouts/warn.html
@@ -1,3 +1,4 @@
 <div class="butter-warning">
+  <button class="close-button icon-remove"></button>
   <span id="warning-content"></span>
 </div>

--- a/public/src/util/accepted-flash.js
+++ b/public/src/util/accepted-flash.js
@@ -14,7 +14,7 @@
       warn: function() {
         var flashVersion = PluginDetect.getVersion( "Flash" );
         if ( !flashVersion || +flashVersion.split( "," )[ 0 ] < MIN_FLASH_VERSION ) {
-          Warn.showWarning( Localized.get( "flashWarning" ) + " " + Localized.get( "Click to remove warning" ) );
+          Warn.showWarning( Localized.get( "flashWarning" ) );
         }
       }
     };

--- a/public/src/util/accepted-ua.js
+++ b/public/src/util/accepted-ua.js
@@ -44,7 +44,7 @@
     }
 
     if ( !acceptedUA ) {
-      Warn.showWarning( Localized.get( "UA_WARNING_TEXT" ) + " " + Localized.get( "Click to remove warning" ) );
+      Warn.showWarning( Localized.get( "UA_WARNING_TEXT" ) );
     }
   });
 }());


### PR DESCRIPTION
This PR:
* changes the link to a button element
* restyles it following @k88hudson's design (https://bugzilla.mozilla.org/show_bug.cgi?id=903611#c11)
* reorders the `Localized.get()` calls so the text flows properly around the new (floated) button on smaller screens