### PR TITLE
Removed audio file status check for Clyp

### DIFF
--- a/public/src/util/mediatypes.js
+++ b/public/src/util/mediatypes.js
@@ -291,9 +291,6 @@ define( [ "localized", "util/uri", "util/xhr", "json!/api/butterconfig", "jquery
           if ( !respData ) {
             return errorCallback( CLYP_EMBED_UNPLAYABLE );
           }
-          if ( respData.Status !== "Public" ) {
-            return errorCallback( CLYP_EMBED_PRIVATE );
-          }
           successCallback({
             source: respData.SecureOggUrl,
             fallback: respData.SecureMp3Url,


### PR DESCRIPTION
If the Clyp API returns a 200, the audio file should be considered importable.