### PR TITLE
Changed version of webmaker-download-locales package to resolve Heroku issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "rtltr-for-less": "0.0.7",
     "sequelize": "^1.7.8",
     "webmaker-auth": "^1.0.2",
-    "webmaker-download-locales": "0.1.2",
+    "webmaker-download-locales": "0.2.5",
     "webmaker-i18n": "0.3.20",
     "webmaker-locale-mapping": "0.0.5",
     "webmaker-mediasync": "0.1.32",


### PR DESCRIPTION
resolves version collision errors between node-expat specified in old webmaker-download-locales & the default Heroku node buildpack.